### PR TITLE
[RFC] Rotating backups

### DIFF
--- a/src/BackupCollection.php
+++ b/src/BackupCollection.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Zenstruck\Backup;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class BackupCollection implements \IteratorAggregate, \Countable
+{
+    private $backups;
+
+    /**
+     * @param Backup[] $backups
+     */
+    public function __construct(array $backups)
+    {
+        usort($backups, function (Backup $a, Backup $b) {
+            $timestampA = $a->getCreatedAt()->getTimestamp();
+            $timestampB = $b->getCreatedAt()->getTimestamp();
+
+            if ($timestampA === $timestampB) {
+                return 0;
+            }
+
+            return ($timestampA < $timestampB) ? -1 : 1;
+        });
+
+        $this->backups = array_values($backups);
+    }
+
+    /**
+     * @param int $key
+     *
+     * @return Backup
+     */
+    public function get($key)
+    {
+        return $this->backups[$key];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->backups);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->backups);
+    }
+
+
+}

--- a/src/BackupCollection.php
+++ b/src/BackupCollection.php
@@ -7,12 +7,13 @@ namespace Zenstruck\Backup;
  */
 final class BackupCollection implements \IteratorAggregate, \Countable
 {
+    /** @var Backup[] */
     private $backups;
 
     /**
      * @param Backup[] $backups
      */
-    public function __construct(array $backups)
+    public function __construct(array $backups = array())
     {
         usort($backups, function (Backup $a, Backup $b) {
             $timestampA = $a->getCreatedAt()->getTimestamp();
@@ -39,6 +40,28 @@ final class BackupCollection implements \IteratorAggregate, \Countable
     }
 
     /**
+     * @return Backup[]
+     */
+    public function all()
+    {
+        return $this->backups;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalFileSize()
+    {
+        $size = 0;
+
+        foreach ($this->backups as $backup) {
+            $size += $backup->getSize();
+        }
+
+        return $size;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getIterator()
@@ -53,6 +76,4 @@ final class BackupCollection implements \IteratorAggregate, \Countable
     {
         return count($this->backups);
     }
-
-
 }

--- a/src/Destination.php
+++ b/src/Destination.php
@@ -30,7 +30,7 @@ interface Destination
     public function delete($key);
 
     /**
-     * @return Backup[]
+     * @return BackupCollection
      */
     public function all();
 

--- a/src/Destination/FlysystemDestination.php
+++ b/src/Destination/FlysystemDestination.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Backup\Destination;
 use League\Flysystem\FilesystemInterface;
 use Psr\Log\LoggerInterface;
 use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
 use Zenstruck\Backup\Destination;
 
 /**
@@ -79,7 +80,7 @@ class FlysystemDestination implements Destination
             );
         }
 
-        return $backups;
+        return new BackupCollection($backups);
     }
 
     /**

--- a/src/Destination/RotatedDestination.php
+++ b/src/Destination/RotatedDestination.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Zenstruck\Backup\Destination;
+
+use Psr\Log\LoggerInterface;
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\Destination;
+use Zenstruck\Backup\RotateStrategy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class RotatedDestination implements Destination
+{
+    private $destination;
+    private $rotateStrategy;
+
+    public function __construct(Destination $destination, RotateStrategy $rotateStrategy)
+    {
+        $this->destination = $destination;
+        $this->rotateStrategy = $rotateStrategy;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function push($filename, LoggerInterface $logger)
+    {
+        $this->doRotate(Backup::fromFile($filename), $logger);
+
+        return $this->destination->push($filename, $logger);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        return $this->destination->get($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        $this->destination->delete($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return $this->destination->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->destination->getName();
+    }
+
+    /**
+     * @param Backup          $newBackup
+     * @param LoggerInterface $logger
+     */
+    private function doRotate(Backup $newBackup, LoggerInterface $logger)
+    {
+        $backups = $this->all();
+
+        if (0 === count($backups)) {
+            return;
+        }
+
+        /** @var Backup[] $backupsToRemove */
+        $backupsToRemove = $this->rotateStrategy->getBackupsToRemove($backups, $newBackup);
+
+        foreach ($backupsToRemove as $backup) {
+            $logger->info(sprintf('Removing backup "%s" from destination "%s"', $backup->getKey(), $this->getName()));
+            $this->delete($backup->getKey());
+        }
+    }
+}

--- a/src/Destination/S3CmdDestination.php
+++ b/src/Destination/S3CmdDestination.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Backup\Destination;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\ProcessBuilder;
 use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
 use Zenstruck\Backup\Destination;
 
 /**
@@ -112,7 +113,7 @@ class S3CmdDestination implements Destination
             throw new \RuntimeException($process->getErrorOutput());
         }
 
-        return $this->parseS3CmdListOutput($process->getOutput());
+        return new BackupCollection($this->parseS3CmdListOutput($process->getOutput()));
     }
 
     /**

--- a/src/Destination/StreamDestination.php
+++ b/src/Destination/StreamDestination.php
@@ -7,6 +7,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
 use Zenstruck\Backup\Destination;
 
 /**
@@ -71,7 +72,7 @@ class StreamDestination implements Destination
             $backups[] = Backup::fromFile($file->getPathname());
         }
 
-        return $backups;
+        return new BackupCollection($backups);
     }
 
     /**

--- a/src/Executor.php
+++ b/src/Executor.php
@@ -24,7 +24,7 @@ final class Executor
      * @param Profile $profile
      * @param bool    $clear
      *
-     * @return Backup[]
+     * @return BackupCollection
      *
      * @throws \Exception
      */
@@ -62,7 +62,7 @@ final class Executor
         $processor->cleanup($filename, $this->logger);
         $this->logger->info('Done.');
 
-        return $backups;
+        return new BackupCollection($backups);
     }
 
     /**

--- a/src/RotateStrategy.php
+++ b/src/RotateStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Zenstruck\Backup;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface RotateStrategy
+{
+    /**
+     * @param BackupCollection $existingBackups
+     * @param Backup           $newBackup
+     *
+     * @return BackupCollection The backups to be removed
+     */
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup);
+}

--- a/src/RotateStrategy/ChainRotateStrategy.php
+++ b/src/RotateStrategy/ChainRotateStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Zenstruck\Backup\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
+use Zenstruck\Backup\RotateStrategy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class ChainRotateStrategy implements RotateStrategy
+{
+    /** @var RotateStrategy[] */
+    private $rotateStrategies;
+
+    /**
+     * @param RotateStrategy[] $rotateStrategies
+     */
+    public function __construct(array $rotateStrategies)
+    {
+        $this->rotateStrategies = $rotateStrategies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    {
+        foreach ($this->rotateStrategies as $rotateStrategy) {
+            $backupsToRemove = $rotateStrategy->getBackupsToRemove($existingBackups, $newBackup);
+
+            if (0 !== count($backupsToRemove)) {
+                return $backupsToRemove;
+            }
+        }
+
+        return new BackupCollection();
+    }
+}

--- a/src/RotateStrategy/MaxCountRotateStrategy.php
+++ b/src/RotateStrategy/MaxCountRotateStrategy.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Zenstruck\Backup\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
+use Zenstruck\Backup\RotateStrategy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class MaxCountRotateStrategy implements RotateStrategy
+{
+    private $maxCount;
+
+    /**
+     * @param int $maxCount
+     */
+    public function __construct($maxCount)
+    {
+        $this->maxCount = $maxCount;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    {
+        $count = count($existingBackups) + 1;
+
+        if ($count <= $this->maxCount) {
+            return new BackupCollection();
+        }
+
+        $backupsToRemove = array();
+
+        for ($i = 0; $i < ($count - $this->maxCount); ++$i) {
+            $backupsToRemove[] = $existingBackups->get($i);
+        }
+
+        return new BackupCollection($backupsToRemove);
+    }
+}

--- a/src/RotateStrategy/MaxSizeRotateStrategy.php
+++ b/src/RotateStrategy/MaxSizeRotateStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Zenstruck\Backup\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
+use Zenstruck\Backup\RotateStrategy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class MaxSizeRotateStrategy implements RotateStrategy
+{
+    private $maxSize;
+
+    /**
+     * @param int $maxSize in bytes
+     */
+    public function __construct($maxSize)
+    {
+        $this->maxSize = $maxSize;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    {
+        $size = $existingBackups->getTotalFileSize() + $newBackup->getSize();
+
+        if ($size < $this->maxSize) {
+            return new BackupCollection();
+        }
+
+        $backupsToRemove = array();
+
+        /** @var Backup[] $existingBackups */
+        foreach ($existingBackups as $backup) {
+            $backupsToRemove[] = $backup;
+            $size -= $backup->getSize();
+
+            if ($size < $this->maxSize) {
+                break;
+            }
+        }
+
+        return new BackupCollection($backupsToRemove);
+    }
+}

--- a/tests/BackupCollectionTest.php
+++ b/tests/BackupCollectionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zenstruck\Backup\Tests;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class BackupCollectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function backups_are_ordered_by_time_oldest_to_newest()
+    {
+        $this->assertSame('yesterday', $this->collection->get(0)->getKey());
+        $this->assertSame('today', $this->collection->get(1)->getKey());
+        $this->assertSame('tomorrow', $this->collection->get(2)->getKey());
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_total_filesize()
+    {
+        $this->assertSame(36, $this->collection->getTotalFileSize());
+    }
+}

--- a/tests/Destination/DestinationTest.php
+++ b/tests/Destination/DestinationTest.php
@@ -62,8 +62,8 @@ abstract class DestinationTest extends TestCase
         $backups = $destination->all();
 
         $this->assertCount(2, $backups);
-        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups[0]);
-        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups[1]);
+        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(1));
+        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(1));
     }
 
     /**

--- a/tests/Destination/DestinationTest.php
+++ b/tests/Destination/DestinationTest.php
@@ -62,8 +62,9 @@ abstract class DestinationTest extends TestCase
         $backups = $destination->all();
 
         $this->assertCount(2, $backups);
-        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(0));
-        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(1));
+        $backups = $backups->all();
+        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups[0]);
+        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups[1]);
     }
 
     /**

--- a/tests/Destination/DestinationTest.php
+++ b/tests/Destination/DestinationTest.php
@@ -62,7 +62,7 @@ abstract class DestinationTest extends TestCase
         $backups = $destination->all();
 
         $this->assertCount(2, $backups);
-        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(1));
+        $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(0));
         $this->assertInstanceOf('Zenstruck\Backup\Backup', $backups->get(1));
     }
 

--- a/tests/Destination/RotatedDestinationTest.php
+++ b/tests/Destination/RotatedDestinationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Zenstruck\Backup\Tests\Destination;
+
+use Zenstruck\Backup\Destination\RotatedDestination;
+use Zenstruck\Backup\Destination\StreamDestination;
+use Zenstruck\Backup\RotateStrategy\ChainRotateStrategy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class RotatedDestinationTest extends DestinationTest
+{
+    /**
+     * @test
+     */
+    public function can_run_rotation()
+    {
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger->expects($this->exactly(3))
+            ->method('info')
+            ->withConsecutive(
+                array('Removing backup "yesterday" from destination "my_destination"'),
+                array('Removing backup "today" from destination "my_destination"'),
+                array('Removing backup "tomorrow" from destination "my_destination"')
+            );
+        $file = $this->getFixtureDir().'/foo.txt';
+        $destination = $this->getMock('Zenstruck\Backup\Destination');
+        $destination->expects($this->once())
+            ->method('push')
+            ->with($file, $logger);
+        $destination->expects($this->once())
+            ->method('all')
+            ->willReturn($this->collection);
+        $destination->expects($this->exactly(3))
+            ->method('delete')
+            ->withConsecutive(array('yesterday'), array('today'), array('tomorrow'));
+        $destination->expects($this->exactly(3))
+            ->method('getName')
+            ->willReturn('my_destination');
+        $strategy = $this->getMock('Zenstruck\Backup\RotateStrategy');
+        $strategy->expects($this->once())
+            ->method('getBackupsToRemove')
+            ->with($this->collection, $this->isInstanceOf('Zenstruck\Backup\Backup'))
+            ->willReturn($this->collection);
+
+        $destination = new RotatedDestination($destination, $strategy);
+        $destination->push($file, $logger);
+    }
+
+    protected function createDestination($directory, $name = 'foo')
+    {
+        return new RotatedDestination(
+            new StreamDestination($name, $directory),
+            new ChainRotateStrategy(array())
+        );
+    }
+}

--- a/tests/RotateStrategy/ChainRotateStrategyTest.php
+++ b/tests/RotateStrategy/ChainRotateStrategyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Zenstruck\Backup\Tests\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\RotateStrategy\ChainRotateStrategy;
+use Zenstruck\Backup\RotateStrategy\MaxCountRotateStrategy;
+use Zenstruck\Backup\RotateStrategy\MaxSizeRotateStrategy;
+use Zenstruck\Backup\Tests\TestCase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class ChainRotateStrategyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function returns_nothing_if_requirements_not_met()
+    {
+        $strategy = new ChainRotateStrategy(array(
+            new MaxSizeRotateStrategy(100),
+            new MaxCountRotateStrategy(10),
+        ));
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(0, $toRemove);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_backups_to_remove()
+    {
+        $strategy = new ChainRotateStrategy(array(
+            new MaxSizeRotateStrategy(100),
+            new MaxCountRotateStrategy(2),
+        ));
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(2, $toRemove);
+        $this->assertSame('yesterday', $toRemove->get(0)->getKey());
+        $this->assertSame('today', $toRemove->get(1)->getKey());
+    }
+}

--- a/tests/RotateStrategy/MaxCountRotateStrategyTest.php
+++ b/tests/RotateStrategy/MaxCountRotateStrategyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zenstruck\Backup\Tests\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\RotateStrategy\MaxCountRotateStrategy;
+use Zenstruck\Backup\Tests\TestCase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class MaxCountRotateStrategyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function returns_nothing_if_max_count_is_not_met()
+    {
+        $strategy = new MaxCountRotateStrategy(10);
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(0, $toRemove);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_backups_to_remove()
+    {
+        $strategy = new MaxCountRotateStrategy(2);
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(2, $toRemove);
+        $this->assertSame('yesterday', $toRemove->get(0)->getKey());
+        $this->assertSame('today', $toRemove->get(1)->getKey());
+    }
+}

--- a/tests/RotateStrategy/MaxSizeRotateStrategyTest.php
+++ b/tests/RotateStrategy/MaxSizeRotateStrategyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zenstruck\Backup\Tests\RotateStrategy;
+
+use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\RotateStrategy\MaxSizeRotateStrategy;
+use Zenstruck\Backup\Tests\TestCase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class MaxSizeRotateStrategyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function returns_nothing_if_max_size_is_not_met()
+    {
+        $strategy = new MaxSizeRotateStrategy(100);
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(0, $toRemove);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_backups_to_remove()
+    {
+        $strategy = new MaxSizeRotateStrategy(20);
+        $toRemove = $strategy->getBackupsToRemove($this->collection, new Backup('foo', 6, new \DateTime()));
+
+        $this->assertCount(2, $toRemove);
+        $this->assertSame('yesterday', $toRemove->get(0)->getKey());
+        $this->assertSame('today', $toRemove->get(1)->getKey());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Backup\Tests;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
 use Zenstruck\Backup\Destination;
 use Zenstruck\Backup\Namer;
 use Zenstruck\Backup\Namer\SimpleNamer;
@@ -20,6 +21,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     /** @var Filesystem */
     protected $filesystem;
 
+    /** @var BackupCollection */
+    protected $collection;
+
     protected function setUp()
     {
         $this->filesystem = new Filesystem();
@@ -27,6 +31,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $this->removeScratchDir();
 
         $this->filesystem->mkdir($this->getScratchDir());
+
+        $this->collection = new BackupCollection(array(
+            new Backup('today', 5, new \DateTime('today')),
+            new Backup('tomorrow', 9, new \DateTime('tomorrow')),
+            new Backup('yesterday', 22, new \DateTime('yesterday')),
+        ));
     }
 
     protected function tearDown()


### PR DESCRIPTION
This is a possible solution for #4. I tried to keep it as simple as possible.

There is a new `Destination` wrapper called `RotatedDestinaion`. This destination extends the `push()` method to first delete any existing backups found via a `RotateStrategy`. 

ping @kachkaev
