### PR TITLE
feat: drop support of php 7.x, drop support symfony < 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+  - 8.0
+  - 8.1
 
 services:
   - mysql
@@ -18,7 +15,7 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 8.0
       env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "zenstruck/backup",
     "description": "Library to create and archive backups",
-    "homepage": "http://zenstruck.com/projects/php-backup",
+    "homepage": "https://zenstruck.com/projects/php-backup",
     "keywords": ["backup"],
     "license": "MIT",
     "authors": [
@@ -11,15 +11,16 @@
         }
     ],
     "require": {
-        "psr/log": "~1.0",
-        "symfony/filesystem": "~3.4|~4.0|~5.0"
+        "php": ">=8.0",
+        "psr/log": "^1.0|^2.0|^3.0",
+        "symfony/filesystem": "^5.4|^6.0"
     },
     "require-dev": {
-        "symfony/process": "~3.4|~4.0|~5.0",
-        "symfony/console": "~3.4|~4.0|~5.0",
-        "symfony/finder": "~3.4|~4.0|~5.0",
-        "league/flysystem": "~1.0",
-        "phpunit/phpunit": "^5.7.11"
+        "symfony/process": "^5.4|^6.0",
+        "symfony/console": "^5.4|^6.0",
+        "symfony/finder": "^5.4|^6.0",
+        "league/flysystem": "^1.1.9",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": { "Zenstruck\\Backup\\": "src/" }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="zenstruck/backup test suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="zenstruck/backup test suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Backup.php
+++ b/src/Backup.php
@@ -9,36 +9,26 @@ use Symfony\Component\Console\Helper\Helper;
  */
 final class Backup
 {
-    private $key;
-    private $size;
-    private $createdAt;
+    private string $key;
+    private int $size;
+    private \DateTime $createdAt;
 
     /**
      * @param string $path The path to the file.
-     *
-     * @return Backup
      */
-    public static function fromFile($path)
+    public static function fromFile(string $path): Backup
     {
         return new self($path, filesize($path), \DateTime::createFromFormat('U', filemtime($path)));
     }
 
-    /**
-     * @param string    $key
-     * @param int       $size
-     * @param \DateTime $createdAt
-     */
-    public function __construct($key, $size, \DateTime $createdAt)
+    public function __construct(string $key, int $size, \DateTime $createdAt)
     {
         $this->key = $key;
-        $this->size = (int) $size;
+        $this->size = $size;
         $this->createdAt = $createdAt;
     }
 
-    /**
-     * @return string
-     */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -46,23 +36,17 @@ final class Backup
     /**
      * @return int The size in bytes.
      */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
 
-    /**
-     * @return string
-     */
-    public function getFormattedSize()
+    public function getFormattedSize(): string
     {
         return \class_exists(Helper::class) ? Helper::formatMemory($this->size) : $this->size.' B';
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getCreatedAt()
+    public function getCreatedAt(): \DateTime
     {
         return $this->createdAt;
     }

--- a/src/BackupCollection.php
+++ b/src/BackupCollection.php
@@ -2,13 +2,15 @@
 
 namespace Zenstruck\Backup;
 
+use Traversable;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class BackupCollection implements \IteratorAggregate, \Countable
 {
     /** @var Backup[] */
-    private $backups;
+    private array $backups;
 
     /**
      * @param Backup[] $backups
@@ -29,12 +31,7 @@ final class BackupCollection implements \IteratorAggregate, \Countable
         $this->backups = array_values($backups);
     }
 
-    /**
-     * @param int $key
-     *
-     * @return Backup
-     */
-    public function get($key)
+    public function get(int $key): Backup
     {
         return $this->backups[$key];
     }
@@ -42,15 +39,12 @@ final class BackupCollection implements \IteratorAggregate, \Countable
     /**
      * @return Backup[]
      */
-    public function all()
+    public function all(): array
     {
         return $this->backups;
     }
 
-    /**
-     * @return int
-     */
-    public function getTotalFileSize()
+    public function getTotalFileSize(): int
     {
         $size = 0;
 
@@ -64,7 +58,7 @@ final class BackupCollection implements \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->backups);
     }
@@ -72,7 +66,7 @@ final class BackupCollection implements \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->backups);
     }

--- a/src/Console/Command/ListCommand.php
+++ b/src/Console/Command/ListCommand.php
@@ -29,7 +29,7 @@ class ListCommand extends ProfileActionCommand
     /**
      * {@inheritdoc}
      */
-    protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output)
+    protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output): int
     {
         foreach ($profile->getDestinations() as $destination) {
             $this->listBackups($destination, $output);

--- a/src/Console/Command/ProfileActionCommand.php
+++ b/src/Console/Command/ProfileActionCommand.php
@@ -17,19 +17,13 @@ abstract class ProfileActionCommand extends BaseCommand
 {
     /**
      * Command specific code.
-     *
-     * @param Profile         $profile
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return int
      */
-    abstract protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output);
+    abstract protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output): int;
 
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $registry = $this->getBackupHelper()->getProfileRegistry();
 
@@ -43,10 +37,9 @@ abstract class ProfileActionCommand extends BaseCommand
     }
 
     /**
-     * @param OutputInterface           $output
      * @param ProfileRegistry|Profile[] $registry
      */
-    protected function listProfiles(OutputInterface $output, ProfileRegistry $registry)
+    protected function listProfiles(OutputInterface $output, ProfileRegistry|array $registry)
     {
         if (0 === count($registry)) {
             throw new \RuntimeException('No profiles configured.');
@@ -72,10 +65,7 @@ abstract class ProfileActionCommand extends BaseCommand
         $output->writeln('');
     }
 
-    /**
-     * @return BackupHelper
-     */
-    protected function getBackupHelper()
+    protected function getBackupHelper(): BackupHelper
     {
         return $this->getHelper('zenstruck_backup');
     }

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Backup\Console\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -28,11 +29,12 @@ class RunCommand extends ProfileActionCommand
 
     /**
      * {@inheritdoc}
+     * @throws \Exception
      */
-    protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output)
+    protected function doExecute(Profile $profile, InputInterface $input, OutputInterface $output): int
     {
         $this->getBackupHelper()->getExecutor()->backup($profile, $input->getOption('clear'));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Console/Helper/BackupHelper.php
+++ b/src/Console/Helper/BackupHelper.php
@@ -11,27 +11,16 @@ use Zenstruck\Backup\ProfileRegistry;
  */
 final class BackupHelper extends Helper
 {
-    private $profileRegistry;
-    private $executor;
-
-    public function __construct(ProfileRegistry $profileRegistry, Executor $executor)
+    public function __construct(private ProfileRegistry $profileRegistry, private Executor $executor)
     {
-        $this->profileRegistry = $profileRegistry;
-        $this->executor = $executor;
     }
 
-    /**
-     * @return ProfileRegistry
-     */
-    public function getProfileRegistry()
+    public function getProfileRegistry(): ProfileRegistry
     {
         return $this->profileRegistry;
     }
 
-    /**
-     * @return Executor
-     */
-    public function getExecutor()
+    public function getExecutor(): Executor
     {
         return $this->executor;
     }
@@ -39,7 +28,7 @@ final class BackupHelper extends Helper
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'zenstruck_backup';
     }

--- a/src/Destination.php
+++ b/src/Destination.php
@@ -9,33 +9,13 @@ use Psr\Log\LoggerInterface;
  */
 interface Destination
 {
-    /**
-     * @param string          $filename
-     * @param LoggerInterface $logger
-     *
-     * @return Backup
-     */
-    public function push($filename, LoggerInterface $logger);
+    public function push(string $filename, LoggerInterface $logger): Backup;
 
-    /**
-     * @param string $key
-     *
-     * @return Backup
-     */
-    public function get($key);
+    public function get(string $key): Backup;
 
-    /**
-     * @param $key
-     */
-    public function delete($key);
+    public function delete(string $key);
 
-    /**
-     * @return BackupCollection
-     */
-    public function all();
+    public function all(): BackupCollection;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Destination/FlysystemDestination.php
+++ b/src/Destination/FlysystemDestination.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\Backup\Destination;
 
+use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 use Psr\Log\LoggerInterface;
 use Zenstruck\Backup\Backup;
@@ -13,23 +14,23 @@ use Zenstruck\Backup\Destination;
  */
 class FlysystemDestination implements Destination
 {
-    private $name;
-    private $filesystem;
+    private string $name;
+    private FilesystemInterface $filesystem;
 
     /**
-     * @param string              $name
+     * @param string $name
      * @param FilesystemInterface $filesystem
      */
-    public function __construct($name, FilesystemInterface $filesystem)
+    public function __construct(string $name, FilesystemInterface $filesystem)
     {
         $this->name = $name;
         $this->filesystem = $filesystem;
     }
 
     /**
-     * {@inheritdoc}
+     * @throws FileNotFoundException
      */
-    public function push($filename, LoggerInterface $logger)
+    public function push(string $filename, LoggerInterface $logger): Backup
     {
         $key = basename($filename);
         $resource = fopen($filename, 'r');
@@ -42,9 +43,9 @@ class FlysystemDestination implements Destination
     }
 
     /**
-     * {@inheritdoc}
+     * @throws FileNotFoundException
      */
-    public function get($key)
+    public function get(string $key): Backup
     {
         return new Backup(
             $key,
@@ -54,17 +55,14 @@ class FlysystemDestination implements Destination
     }
 
     /**
-     * {@inheritdoc}
+     * @throws FileNotFoundException
      */
     public function delete($key)
     {
         $this->filesystem->delete($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function all()
+    public function all(): BackupCollection
     {
         $backups = array();
 
@@ -83,10 +81,7 @@ class FlysystemDestination implements Destination
         return new BackupCollection($backups);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Destination/RotatedDestination.php
+++ b/src/Destination/RotatedDestination.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Backup\Destination;
 
 use Psr\Log\LoggerInterface;
 use Zenstruck\Backup\Backup;
+use Zenstruck\Backup\BackupCollection;
 use Zenstruck\Backup\Destination;
 use Zenstruck\Backup\RotateStrategy;
 
@@ -12,53 +13,33 @@ use Zenstruck\Backup\RotateStrategy;
  */
 class RotatedDestination implements Destination
 {
-    private $destination;
-    private $rotateStrategy;
-
-    public function __construct(Destination $destination, RotateStrategy $rotateStrategy)
+    public function __construct(private Destination $destination, private RotateStrategy $rotateStrategy)
     {
-        $this->destination = $destination;
-        $this->rotateStrategy = $rotateStrategy;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function push($filename, LoggerInterface $logger)
+    public function push(string $filename, LoggerInterface $logger): Backup
     {
         $this->doRotate(Backup::fromFile($filename), $logger);
 
         return $this->destination->push($filename, $logger);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function get($key)
+    public function get(string $key): Backup
     {
         return $this->destination->get($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete($key)
     {
         $this->destination->delete($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function all()
+    public function all(): BackupCollection
     {
         return $this->destination->all();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->destination->getName();
     }

--- a/src/Destination/StreamDestination.php
+++ b/src/Destination/StreamDestination.php
@@ -15,25 +15,22 @@ use Zenstruck\Backup\Destination;
  */
 class StreamDestination implements Destination
 {
-    private $name;
-    private $directory;
-    private $filesystem;
+    private string $name;
+    private string $directory;
+    private Filesystem $filesystem;
 
     /**
      * @param string $name
      * @param string $directory
      */
-    public function __construct($name, $directory)
+    public function __construct(string $name, string $directory)
     {
         $this->name = $name;
         $this->directory = $directory;
         $this->filesystem = new Filesystem();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function push($filename, LoggerInterface $logger)
+    public function push(string $filename, LoggerInterface $logger): Backup
     {
         $logger->info(sprintf('Copying %s to %s', $filename, $this->directory));
 
@@ -42,26 +39,17 @@ class StreamDestination implements Destination
         return $this->get($filename);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function get($key)
+    public function get(string $key): Backup
     {
         return Backup::fromFile($this->createPath($key));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete($key)
     {
         $this->filesystem->remove($this->createPath($key));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function all()
+    public function all(): BackupCollection
     {
         $backups = array();
 
@@ -75,10 +63,7 @@ class StreamDestination implements Destination
         return new BackupCollection($backups);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -88,7 +73,7 @@ class StreamDestination implements Destination
      *
      * @return string
      */
-    private function createPath($key)
+    private function createPath(string $key): string
     {
         return sprintf('%s/%s', $this->directory, basename($key));
     }

--- a/src/Executor.php
+++ b/src/Executor.php
@@ -10,25 +10,14 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class Executor
 {
-    private $logger;
-
-    /**
-     * @param LoggerInterface $logger
-     */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(private LoggerInterface $logger)
     {
-        $this->logger = $logger;
     }
 
     /**
-     * @param Profile $profile
-     * @param bool    $clear
-     *
-     * @return BackupCollection
-     *
      * @throws \Exception
      */
-    public function backup(Profile $profile, $clear = false)
+    public function backup(Profile $profile, bool $clear = false): BackupCollection
     {
         $scratchDir = $profile->getScratchDir();
         $processor = $profile->getProcessor();
@@ -66,12 +55,9 @@ final class Executor
     }
 
     /**
-     * @param Profile $profile
-     * @param string  $filename
-     *
      * @return Backup[]
      */
-    private function sendToDestinations(Profile $profile, $filename)
+    private function sendToDestinations(Profile $profile, string $filename): array
     {
         $backups = array();
 

--- a/src/Namer.php
+++ b/src/Namer.php
@@ -7,13 +7,7 @@ namespace Zenstruck\Backup;
  */
 interface Namer
 {
-    /**
-     * @return string
-     */
-    public function generate();
+    public function generate(): string;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Namer/SimpleNamer.php
+++ b/src/Namer/SimpleNamer.php
@@ -11,28 +11,22 @@ class SimpleNamer implements Namer
 {
     const DEFAULT_NAME = 'backup';
 
-    private $name;
+    private string $name;
 
     /**
      * @param string $name
      */
-    public function __construct($name = self::DEFAULT_NAME)
+    public function __construct(string $name = self::DEFAULT_NAME)
     {
         $this->name = $name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function generate()
+    public function generate(): string
     {
         return $this->name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Namer/TimestampNamer.php
+++ b/src/Namer/TimestampNamer.php
@@ -12,39 +12,24 @@ class TimestampNamer implements Namer
     const DEFAULT_FORMAT = 'YmdHis';
     const DEFAULT_PREFIX = '';
 
-    private $name;
-    private $format;
-    private $prefix;
-    private $timezone;
+    private ?\DateTimeZone $timezone;
 
-    /**
-     * @param string      $name
-     * @param string      $format
-     * @param string      $prefix
-     * @param string|null $timezone
-     */
-    public function __construct($name, $format = self::DEFAULT_FORMAT, $prefix = self::DEFAULT_PREFIX, $timezone = null)
+    public function __construct(private string $name, private string $format = self::DEFAULT_FORMAT, private string $prefix = self::DEFAULT_PREFIX, ?string $timezone = null)
     {
-        $this->name = $name;
-        $this->format = $format;
-        $this->prefix = $prefix;
         $this->timezone = $timezone ? new \DateTimeZone($timezone) : null;
     }
 
     /**
-     * {@inheritdoc}
+     * @throws \Exception
      */
-    public function generate()
+    public function generate(): string
     {
         $dateTime = new \DateTime('now', $this->timezone);
 
         return $this->prefix.$dateTime->format($this->format);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -10,22 +10,16 @@ use Psr\Log\LoggerInterface;
 interface Processor
 {
     /**
-     * @param string          $scratchDir Path to the scratch directory
-     * @param Namer           $namer
-     * @param LoggerInterface $logger
+     * @param string $scratchDir Path to the scratch directory
      *
      * @return string The filename to backup
      */
-    public function process($scratchDir, Namer $namer, LoggerInterface $logger);
+    public function process(string $scratchDir, Namer $namer, LoggerInterface $logger): string;
 
     /**
-     * @param string          $filename The file to cleanup
-     * @param LoggerInterface $logger
+     * @param string $filename The file to cleanup
      */
-    public function cleanup($filename, LoggerInterface $logger);
+    public function cleanup(string $filename, LoggerInterface $logger);
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Processor/ArchiveProcessor.php
+++ b/src/Processor/ArchiveProcessor.php
@@ -14,32 +14,14 @@ abstract class ArchiveProcessor implements Processor
 {
     const DEFAULT_TIMEOUT = 300;
 
-    private $name;
-    private $command;
-    private $options;
-    private $extension;
-    private $timeout;
-
-    /**
-     * @param string $name
-     * @param string $command
-     * @param string $options
-     * @param string $extension
-     * @param int    $timeout
-     */
-    public function __construct($name, $command, $options, $extension, $timeout = self::DEFAULT_TIMEOUT)
+    public function __construct(private string $name, private string $command, private string $options, private string $extension, private int $timeout = self::DEFAULT_TIMEOUT)
     {
-        $this->name = $name;
-        $this->command = $command;
-        $this->options = $options;
-        $this->extension = $extension;
-        $this->timeout = $timeout;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function process($scratchDir, Namer $namer, LoggerInterface $logger)
+    public function process(string $scratchDir, Namer $namer, LoggerInterface $logger): string
     {
         $filename = sprintf('%s/%s.%s', sys_get_temp_dir(), $namer->generate(), $this->extension);
 
@@ -59,7 +41,7 @@ abstract class ArchiveProcessor implements Processor
     /**
      * {@inheritdoc}
      */
-    public function cleanup($filename, LoggerInterface $logger)
+    public function cleanup(string $filename, LoggerInterface $logger)
     {
         $logger->info(sprintf('Deleting %s', $filename));
 
@@ -68,10 +50,7 @@ abstract class ArchiveProcessor implements Processor
         }
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -7,27 +7,20 @@ namespace Zenstruck\Backup;
  */
 final class Profile
 {
-    private $name;
-    private $scratchDir;
-    private $namer;
-    private $processor;
-    private $sources;
-    private $destinations;
+    private array $sources;
+    private array $destinations;
 
     /**
-     * @param string        $name
-     * @param string        $scratchDir
-     * @param Processor     $processor
-     * @param Namer         $namer
      * @param Source[]      $sources
      * @param Destination[] $destinations
      */
-    public function __construct($name, $scratchDir, Processor $processor, Namer $namer, array $sources, array $destinations)
+    public function __construct(private string    $name,
+                                private string    $scratchDir,
+                                private Processor $processor,
+                                private Namer     $namer,
+                                array             $sources,
+                                array             $destinations)
     {
-        $this->name = $name;
-        $this->scratchDir = $scratchDir;
-        $this->processor = $processor;
-        $this->namer = $namer;
 
         foreach ($sources as $source) {
             $this->addSource($source);
@@ -38,34 +31,22 @@ final class Profile
         }
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
-    public function getScratchDir()
+    public function getScratchDir(): string
     {
         return $this->scratchDir;
     }
 
-    /**
-     * @return Namer
-     */
-    public function getNamer()
+    public function getNamer(): Namer
     {
         return $this->namer;
     }
 
-    /**
-     * @return Processor
-     */
-    public function getProcessor()
+    public function getProcessor(): Processor
     {
         return $this->processor;
     }
@@ -73,7 +54,7 @@ final class Profile
     /**
      * @return Source[]
      */
-    public function getSources()
+    public function getSources(): array
     {
         return $this->sources;
     }
@@ -81,17 +62,17 @@ final class Profile
     /**
      * @return Destination[]
      */
-    public function getDestinations()
+    public function getDestinations(): array
     {
         return $this->destinations;
     }
 
-    private function addSource(Source $source)
+    private function addSource(Source $source): void
     {
         $this->sources[$source->getName()] = $source;
     }
 
-    private function addDestination(Destination $destination)
+    private function addDestination(Destination $destination): void
     {
         $this->destinations[$destination->getName()] = $destination;
     }

--- a/src/ProfileBuilder.php
+++ b/src/ProfileBuilder.php
@@ -7,10 +7,10 @@ namespace Zenstruck\Backup;
  */
 final class ProfileBuilder
 {
-    private $processors;
-    private $namers;
-    private $sources;
-    private $destinations;
+    private array $processors;
+    private array $namers;
+    private array $sources;
+    private array $destinations;
 
     /**
      * @param Processor[]   $processors
@@ -18,7 +18,10 @@ final class ProfileBuilder
      * @param Source[]      $sources
      * @param Destination[] $destinations
      */
-    public function __construct(array $processors = array(), array $namers = array(), array $sources = array(), array $destinations = array())
+    public function __construct(array $processors = [],
+                                array $namers = [],
+                                array $sources = [],
+                                array $destinations = [])
     {
         foreach ($processors as $processor) {
             $this->addProcessor($processor);
@@ -38,16 +41,10 @@ final class ProfileBuilder
     }
 
     /**
-     * @param string $name
-     * @param string $scratchDir
-     * @param string $processor
-     * @param string $namer
-     * @param array  $sources
-     * @param array  $destinations
-     *
-     * @return Profile
+     * @param Source[] $sources
+     * @param Destination[] $destinations
      */
-    public function create($name, $scratchDir, $processor, $namer, array $sources, array $destinations)
+    public function create(string $name, string $scratchDir, string $processor, string $namer, array $sources, array $destinations): Profile
     {
         return new Profile(
             $name,
@@ -59,20 +56,12 @@ final class ProfileBuilder
         );
     }
 
-    /**
-     * @param Source $source
-     */
-    public function addSource(Source $source)
+    public function addSource(Source $source): void
     {
         $this->sources[$source->getName()] = $source;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Source
-     */
-    public function getSource($name)
+    public function getSource(string $name): Source
     {
         if (!isset($this->sources[$name])) {
             throw new \InvalidArgumentException(sprintf('Source "%s" is not registered.', $name));
@@ -86,7 +75,7 @@ final class ProfileBuilder
      *
      * @return Source[]
      */
-    public function getSources(array $names)
+    public function getSources(array $names): array
     {
         $self = $this;
 
@@ -95,20 +84,12 @@ final class ProfileBuilder
         }, $names);
     }
 
-    /**
-     * @param Namer $namer
-     */
-    public function addNamer(Namer $namer)
+    public function addNamer(Namer $namer): void
     {
         $this->namers[$namer->getName()] = $namer;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Namer
-     */
-    public function getNamer($name)
+    public function getNamer(string $name): Namer
     {
         if (!isset($this->namers[$name])) {
             throw new \InvalidArgumentException(sprintf('Namer "%s" is not registered.', $name));
@@ -117,20 +98,12 @@ final class ProfileBuilder
         return $this->namers[$name];
     }
 
-    /**
-     * @param Processor $processor
-     */
-    public function addProcessor(Processor $processor)
+    public function addProcessor(Processor $processor): void
     {
         $this->processors[$processor->getName()] = $processor;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Processor
-     */
-    public function getProcessor($name)
+    public function getProcessor(string $name): Processor
     {
         if (!isset($this->processors[$name])) {
             throw new \InvalidArgumentException(sprintf('Processor "%s" is not registered.', $name));
@@ -139,20 +112,12 @@ final class ProfileBuilder
         return $this->processors[$name];
     }
 
-    /**
-     * @param Destination $destination
-     */
-    public function addDestination(Destination $destination)
+    public function addDestination(Destination $destination): void
     {
         $this->destinations[$destination->getName()] = $destination;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Destination
-     */
-    public function getDestination($name)
+    public function getDestination(string $name): Destination
     {
         if (!isset($this->destinations[$name])) {
             throw new \InvalidArgumentException(sprintf('Destination "%s" is not registered.', $name));
@@ -166,7 +131,7 @@ final class ProfileBuilder
      *
      * @return Destination[]
      */
-    public function getDestinations(array $names)
+    public function getDestinations(array $names): array
     {
         $self = $this;
 

--- a/src/ProfileRegistry.php
+++ b/src/ProfileRegistry.php
@@ -2,38 +2,32 @@
 
 namespace Zenstruck\Backup;
 
+use Traversable;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class ProfileRegistry implements \Countable, \IteratorAggregate
 {
     /** @var Profile[] */
-    private $profiles = array();
+    private array $profiles = [];
 
     /**
      * @param Profile[] $profiles
      */
-    public function __construct(array $profiles = array())
+    public function __construct(array $profiles = [])
     {
         foreach ($profiles as $profile) {
             $this->add($profile);
         }
     }
 
-    /**
-     * @param Profile $profile
-     */
     public function add(Profile $profile)
     {
         $this->profiles[$profile->getName()] = $profile;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return Profile
-     */
-    public function get($name)
+    public function get(string $name): Profile
     {
         if (!isset($this->profiles[$name])) {
             throw new \InvalidArgumentException(sprintf('Profile "%s" is not registered.', $name));
@@ -45,7 +39,7 @@ final class ProfileRegistry implements \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->profiles);
     }
@@ -53,7 +47,7 @@ final class ProfileRegistry implements \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->profiles);
     }

--- a/src/RotateStrategy.php
+++ b/src/RotateStrategy.php
@@ -8,10 +8,7 @@ namespace Zenstruck\Backup;
 interface RotateStrategy
 {
     /**
-     * @param BackupCollection $existingBackups
-     * @param Backup           $newBackup
-     *
      * @return BackupCollection The backups to be removed
      */
-    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup);
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup): BackupCollection;
 }

--- a/src/RotateStrategy/ChainRotateStrategy.php
+++ b/src/RotateStrategy/ChainRotateStrategy.php
@@ -12,7 +12,7 @@ use Zenstruck\Backup\RotateStrategy;
 class ChainRotateStrategy implements RotateStrategy
 {
     /** @var RotateStrategy[] */
-    private $rotateStrategies;
+    private array $rotateStrategies;
 
     /**
      * @param RotateStrategy[] $rotateStrategies
@@ -25,7 +25,7 @@ class ChainRotateStrategy implements RotateStrategy
     /**
      * {@inheritdoc}
      */
-    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup): BackupCollection
     {
         foreach ($this->rotateStrategies as $rotateStrategy) {
             $backupsToRemove = $rotateStrategy->getBackupsToRemove($existingBackups, $newBackup);

--- a/src/RotateStrategy/MaxCountRotateStrategy.php
+++ b/src/RotateStrategy/MaxCountRotateStrategy.php
@@ -11,20 +11,14 @@ use Zenstruck\Backup\RotateStrategy;
  */
 class MaxCountRotateStrategy implements RotateStrategy
 {
-    private $maxCount;
-
-    /**
-     * @param int $maxCount
-     */
-    public function __construct($maxCount)
+    public function __construct(private int $maxCount)
     {
-        $this->maxCount = $maxCount;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup): BackupCollection
     {
         $count = count($existingBackups) + 1;
 

--- a/src/RotateStrategy/MaxSizeRotateStrategy.php
+++ b/src/RotateStrategy/MaxSizeRotateStrategy.php
@@ -11,20 +11,17 @@ use Zenstruck\Backup\RotateStrategy;
  */
 class MaxSizeRotateStrategy implements RotateStrategy
 {
-    private $maxSize;
-
     /**
      * @param int $maxSize in bytes
      */
-    public function __construct($maxSize)
+    public function __construct(private int $maxSize)
     {
-        $this->maxSize = $maxSize;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup)
+    public function getBackupsToRemove(BackupCollection $existingBackups, Backup $newBackup): BackupCollection
     {
         $size = $existingBackups->getTotalFileSize() + $newBackup->getSize();
 

--- a/src/Source.php
+++ b/src/Source.php
@@ -10,13 +10,9 @@ use Psr\Log\LoggerInterface;
 interface Source
 {
     /**
-     * @param string          $scratchDir Path to the scratch directory
-     * @param LoggerInterface $logger
+     * @param string $scratchDir Path to the scratch directory
      */
-    public function fetch($scratchDir, LoggerInterface $logger);
+    public function fetch(string $scratchDir, LoggerInterface $logger);
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Source/MySqlDumpSource.php
+++ b/src/Source/MySqlDumpSource.php
@@ -15,44 +15,22 @@ class MySqlDumpSource implements Source
     const DEFAULT_SSH_PORT = 22;
     const DEFAULT_TIMEOUT = 300;
 
-    private $name;
-    private $database;
-    private $host;
-    private $user;
-    private $password;
-    private $sshHost;
-    private $sshUser;
-    private $sshPort;
-    private $timeout;
-
-    /**
-     * @param string      $name
-     * @param string      $database
-     * @param string|null $host
-     * @param string      $user
-     * @param string|null $password
-     * @param string|null $sshHost
-     * @param string|null $sshUser
-     * @param int         $sshPort
-     * @param int         $timeout
-     */
-    public function __construct($name, $database, $host = null, $user = self::DEFAULT_USER, $password = null, $sshHost = null, $sshUser = null, $sshPort = self::DEFAULT_SSH_PORT, $timeout = self::DEFAULT_TIMEOUT)
+    public function __construct(private string  $name,
+                                private string  $database,
+                                private ?string $host = null,
+                                private string  $user = self::DEFAULT_USER,
+                                private ?string $password = null,
+                                private ?string $sshHost = null,
+                                private ?string $sshUser = null,
+                                private int     $sshPort = self::DEFAULT_SSH_PORT,
+                                private int     $timeout = self::DEFAULT_TIMEOUT)
     {
-        $this->name = $name;
-        $this->database = $database;
-        $this->host = $host;
-        $this->user = $user;
-        $this->password = $password;
-        $this->sshHost = $sshHost;
-        $this->sshUser = $sshUser;
-        $this->sshPort = $sshPort;
-        $this->timeout = $timeout;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetch($scratchDir, LoggerInterface $logger)
+    public function fetch(string $scratchDir, LoggerInterface $logger)
     {
         $logger->info(sprintf('Running mysqldump for: %s', $this->database));
 
@@ -88,10 +66,7 @@ class MySqlDumpSource implements Source
         file_put_contents(sprintf('%s/%s.sql', $scratchDir, $this->database), $process->getOutput());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Source/RsyncSource.php
+++ b/src/Source/RsyncSource.php
@@ -13,33 +13,29 @@ class RsyncSource implements Source
 {
     const DEFAULT_TIMEOUT = 300;
 
-    private $name;
-    private $source;
-    private $options;
-    private $timeout;
+    private array $options;
 
     /**
-     * @param string $name
      * @param string $source            The rsync source
      * @param array  $additionalOptions Additional rsync options (useful for excludes)
      * @param array  $defaultOptions    Default rsync options
-     * @param int    $timeout
      */
-    public function __construct($name, $source, array $additionalOptions = array(), array $defaultOptions = array(), $timeout = self::DEFAULT_TIMEOUT)
+    public function __construct(private string $name,
+                                private string $source,
+                                array          $additionalOptions = [],
+                                array          $defaultOptions = [],
+                                private int    $timeout = self::DEFAULT_TIMEOUT)
     {
         $defaultOptions = count($defaultOptions) ? $defaultOptions : static::getDefaultOptions();
 
-        $this->name = $name;
-        $this->source = $source;
         $this->options = $defaultOptions;
-        $this->timeout = $timeout;
 
         foreach ($additionalOptions as $option) {
             $this->options[] = $option;
         }
     }
 
-    public static function getDefaultOptions()
+    public static function getDefaultOptions(): array
     {
         return array('-acrv', '--force', '--delete', '--progress', '--delete-excluded');
     }
@@ -47,7 +43,7 @@ class RsyncSource implements Source
     /**
      * {@inheritdoc}
      */
-    public function fetch($scratchDir, LoggerInterface $logger)
+    public function fetch(string $scratchDir, LoggerInterface $logger)
     {
         $logger->info(sprintf('Syncing files from: %s', $this->source));
 
@@ -61,10 +57,7 @@ class RsyncSource implements Source
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/Console/Command/ListCommandTest.php
+++ b/tests/Console/Command/ListCommandTest.php
@@ -34,15 +34,15 @@ class ListCommandTest extends ProfileActionCommandTest
             array('command' => $this->getCommandName(), 'profile' => 'foo')
         );
 
-        $this->assertContains('foo.txt | 4', $commandTester->getDisplay());
-        $this->assertContains('bam.txt | 4', $commandTester->getDisplay());
-        $this->assertNotContains('baz.txt | 4', $commandTester->getDisplay());
+        $this->assertStringContainsString('foo.txt | 4', $commandTester->getDisplay());
+        $this->assertStringContainsString('bam.txt | 4', $commandTester->getDisplay());
+        $this->assertStringNotContainsString('baz.txt | 4', $commandTester->getDisplay());
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function createCommand()
+    protected function createCommand(): ListCommand|\Zenstruck\Backup\Console\Command\ProfileActionCommand
     {
         return new ListCommand();
     }
@@ -50,7 +50,7 @@ class ListCommandTest extends ProfileActionCommandTest
     /**
      * {@inheritdoc}
      */
-    protected function getCommandName()
+    protected function getCommandName(): string
     {
         return 'zenstruck:backup:list';
     }

--- a/tests/Console/Command/ProfileActionCommandTest.php
+++ b/tests/Console/Command/ProfileActionCommandTest.php
@@ -26,7 +26,7 @@ abstract class ProfileActionCommandTest extends TestCase
             array('command' => $this->getCommandName())
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'foo  | null_processor | backup | null_source1, null_source2 | null_destination1, null_destination2',
             $commandTester->getDisplay()
         );
@@ -35,11 +35,13 @@ abstract class ProfileActionCommandTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Profile "foo" is not registered.
+     *
+     *
      */
     public function it_fails_when_asking_for_undefined_profile()
     {
+        $this->expectExceptionMessage("Profile \"foo\" is not registered.");
+        $this->expectException(\InvalidArgumentException::class);
         $commandTester = $this->createCommandTester();
         $commandTester->execute(
             array('command' => $this->getCommandName(), 'profile' => 'foo')
@@ -49,11 +51,13 @@ abstract class ProfileActionCommandTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No profiles configured.
+     *
+     *
      */
     public function it_fails_when_listing_no_profiles()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("No profiles configured.");
         $commandTester = $this->createCommandTester();
         $commandTester->execute(
             array('command' => 'zenstruck:backup:run')
@@ -62,11 +66,11 @@ abstract class ProfileActionCommandTest extends TestCase
 
     /**
      * @param Profile[] $profiles
-     * @param null|int  $infoCalls
+     * @param int|null $infoCalls
      *
      * @return CommandTester
      */
-    protected function createCommandTester(array $profiles = array(), $infoCalls = 0)
+    protected function createCommandTester(array $profiles = array(), ?int $infoCalls = 0): CommandTester
     {
         $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger
@@ -85,10 +89,10 @@ abstract class ProfileActionCommandTest extends TestCase
     /**
      * @return ProfileActionCommand
      */
-    abstract protected function createCommand();
+    abstract protected function createCommand(): ProfileActionCommand;
 
     /**
      * @return string
      */
-    abstract protected function getCommandName();
+    abstract protected function getCommandName(): string;
 }

--- a/tests/Console/Command/RunCommandTest.php
+++ b/tests/Console/Command/RunCommandTest.php
@@ -34,7 +34,7 @@ class RunCommandTest extends ProfileActionCommandTest
     /**
      * {@inheritdoc}
      */
-    protected function getCommandName()
+    protected function getCommandName(): string
     {
         return 'zenstruck:backup:run';
     }
@@ -42,7 +42,7 @@ class RunCommandTest extends ProfileActionCommandTest
     /**
      * {@inheritdoc}
      */
-    protected function createCommand()
+    protected function createCommand(): RunCommand|\Zenstruck\Backup\Console\Command\ProfileActionCommand
     {
         return new RunCommand();
     }

--- a/tests/Destination/DestinationTest.php
+++ b/tests/Destination/DestinationTest.php
@@ -20,7 +20,7 @@ abstract class DestinationTest extends TestCase
         $destinationDir = $this->getScratchDir();
         $destinationFile = $destinationDir.'/foo.txt';
         $destination = $this->createDestination($destinationDir);
-        $this->assertFileNotExists($destinationFile);
+        $this->assertFileDoesNotExist($destinationFile);
 
         $destination->push($file, new NullLogger());
         $this->assertFileExists($destinationFile);
@@ -34,7 +34,7 @@ abstract class DestinationTest extends TestCase
         $this->prepareScratch();
         $destination = $this->createDestination($this->getScratchDir());
         $backup = $destination->get('foo.txt');
-        $this->assertContains('foo.txt', $backup->getKey());
+        $this->assertStringContainsString('foo.txt', $backup->getKey());
         $this->assertSame(4, $backup->getSize());
         $this->assertInstanceOf('\DateTime', $backup->getCreatedAt());
     }
@@ -49,7 +49,7 @@ abstract class DestinationTest extends TestCase
 
         $destination = $this->createDestination($this->getScratchDir());
         $destination->delete('foo.txt');
-        $this->assertFileNotExists($this->getScratchDir().'/foo.txt');
+        $this->assertFileDoesNotExist($this->getScratchDir().'/foo.txt');
     }
 
     /**
@@ -83,7 +83,7 @@ abstract class DestinationTest extends TestCase
      *
      * @return Destination
      */
-    abstract protected function createDestination($directory, $name = 'foo');
+    abstract protected function createDestination(string $directory, string $name = 'foo'): Destination;
 
     private function prepareScratch()
     {

--- a/tests/Destination/FlysystemDestinationTest.php
+++ b/tests/Destination/FlysystemDestinationTest.php
@@ -11,7 +11,7 @@ use Zenstruck\Backup\Destination\FlysystemDestination;
  */
 class FlysystemDestinationTest extends DestinationTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('League\Flysystem\Filesystem')) {
             $this->markTestSkipped('Flysystem not available.');
@@ -20,7 +20,7 @@ class FlysystemDestinationTest extends DestinationTest
         parent::setUp();
     }
 
-    protected function createDestination($directory, $name = 'foo')
+    protected function createDestination(string $directory, string $name = 'foo'): FlysystemDestination
     {
         return new FlysystemDestination($name, new Filesystem(new Local($directory)));
     }

--- a/tests/Destination/RotatedDestinationTest.php
+++ b/tests/Destination/RotatedDestinationTest.php
@@ -20,9 +20,9 @@ class RotatedDestinationTest extends DestinationTest
         $logger->expects($this->exactly(3))
             ->method('info')
             ->withConsecutive(
-                array('Removing backup "yesterday" from destination "my_destination"'),
-                array('Removing backup "today" from destination "my_destination"'),
-                array('Removing backup "tomorrow" from destination "my_destination"')
+                ['Removing backup "yesterday" from destination "my_destination"'],
+                ['Removing backup "today" from destination "my_destination"'],
+                ['Removing backup "tomorrow" from destination "my_destination"']
             );
         $file = $this->getFixtureDir().'/foo.txt';
         $destination = $this->createMock('Zenstruck\Backup\Destination');
@@ -48,7 +48,7 @@ class RotatedDestinationTest extends DestinationTest
         $destination->push($file, $logger);
     }
 
-    protected function createDestination($directory, $name = 'foo')
+    protected function createDestination(string $directory, string $name = 'foo'): RotatedDestination
     {
         return new RotatedDestination(
             new StreamDestination($name, $directory),

--- a/tests/Destination/S3CmdDestinationTest.php
+++ b/tests/Destination/S3CmdDestinationTest.php
@@ -41,7 +41,7 @@ class S3CmdDestinationTest extends DestinationTest
         $this->markTestIncomplete('Test not available for S3CmdDestination');
     }
 
-    public function createDestination($directory, $name = 'foo')
+    public function createDestination(string $directory, string $name = 'foo'): S3CmdDestination
     {
         return new S3CmdDestination($name, 'n/a');
     }

--- a/tests/Destination/StreamDestinationTest.php
+++ b/tests/Destination/StreamDestinationTest.php
@@ -9,7 +9,7 @@ use Zenstruck\Backup\Destination\StreamDestination;
  */
 class StreamDestinationTest extends DestinationTest
 {
-    protected function createDestination($directory, $name = 'foo')
+    protected function createDestination(string $directory, string $name = 'foo'): StreamDestination
     {
         return new StreamDestination($name, $directory);
     }

--- a/tests/Namer/TimestampNamerTest.php
+++ b/tests/Namer/TimestampNamerTest.php
@@ -33,14 +33,13 @@ class TimestampNamerTest extends TestCase
         $this->assertSame('timestamp', $namer->getName());
     }
 
-    public static function nameProvider()
+    public static function nameProvider(): array
     {
-        return array(
-            array(TimestampNamer::DEFAULT_FORMAT, TimestampNamer::DEFAULT_PREFIX),
-            array(TimestampNamer::DEFAULT_FORMAT, TimestampNamer::DEFAULT_PREFIX, 'UTC'),
-            array('d', null),
-            array('dm', null),
-            array('s', 'foo-'),
-        );
+        return [
+            [TimestampNamer::DEFAULT_FORMAT, TimestampNamer::DEFAULT_PREFIX],
+            [TimestampNamer::DEFAULT_FORMAT, TimestampNamer::DEFAULT_PREFIX, 'UTC'],
+            ['d', ''],
+            ['s', 'foo-'],
+        ];
     }
 }

--- a/tests/Processor/ArchiveProcessorTest.php
+++ b/tests/Processor/ArchiveProcessorTest.php
@@ -19,14 +19,14 @@ abstract class ArchiveProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
         $logger = new NullLogger();
-        $this->assertFileNotExists($this->getTempFilename());
+        $this->assertFileDoesNotExist($this->getTempFilename());
 
         $filename = $processor->process($this->getFixtureDir(), new SimpleNamer('zenstruck-backup-foo'), $logger);
         $this->assertFileExists($filename);
         $this->assertSame($filename, $this->getTempFilename());
 
         $processor->cleanup($filename, $logger);
-        $this->assertFileNotExists($filename);
+        $this->assertFileDoesNotExist($filename);
     }
 
     /**
@@ -40,21 +40,21 @@ abstract class ArchiveProcessorTest extends TestCase
     /**
      * @return ArchiveProcessor
      */
-    abstract protected function getProcessor();
+    abstract protected function getProcessor(): ArchiveProcessor;
 
     /**
      * @return string
      */
-    abstract protected function getExtension();
+    abstract protected function getExtension(): string;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->deleteTempFile();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -70,7 +70,7 @@ abstract class ArchiveProcessorTest extends TestCase
         }
     }
 
-    private function getTempFilename()
+    private function getTempFilename(): string
     {
         return sys_get_temp_dir().'/zenstruck-backup-foo.'.$this->getExtension();
     }

--- a/tests/Processor/GzipArchiveProcessorTest.php
+++ b/tests/Processor/GzipArchiveProcessorTest.php
@@ -12,7 +12,7 @@ class GzipArchiveProcessorTest extends ArchiveProcessorTest
     /**
      * {@inheritdoc}
      */
-    protected function getProcessor()
+    protected function getProcessor(): GzipArchiveProcessor|\Zenstruck\Backup\Processor\ArchiveProcessor
     {
         return new GzipArchiveProcessor('archive');
     }
@@ -20,7 +20,7 @@ class GzipArchiveProcessorTest extends ArchiveProcessorTest
     /**
      * {@inheritdoc}
      */
-    protected function getExtension()
+    protected function getExtension(): string
     {
         return 'tar.gz';
     }

--- a/tests/Processor/ZipArchiveProcessorTest.php
+++ b/tests/Processor/ZipArchiveProcessorTest.php
@@ -12,7 +12,7 @@ class ZipArchiveProcessorTest extends ArchiveProcessorTest
     /**
      * {@inheritdoc}
      */
-    protected function getProcessor()
+    protected function getProcessor(): \Zenstruck\Backup\Processor\ArchiveProcessor|ZipArchiveProcessor
     {
         return new ZipArchiveProcessor('archive');
     }
@@ -20,7 +20,7 @@ class ZipArchiveProcessorTest extends ArchiveProcessorTest
     /**
      * {@inheritdoc}
      */
-    protected function getExtension()
+    protected function getExtension(): string
     {
         return 'zip';
     }

--- a/tests/ProfileBuilderTest.php
+++ b/tests/ProfileBuilderTest.php
@@ -54,13 +54,14 @@ class ProfileBuilderTest extends TestCase
      */
     public function it_throws_exceptions_when_asking_for_invalid_items($method, $message)
     {
-        $this->setExpectedException('\InvalidArgumentException', $message);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
 
         $builder = new ProfileBuilder();
         $builder->$method('foo');
     }
 
-    public static function invalidItemProvider()
+    public static function invalidItemProvider(): array
     {
         return array(
             array('getProcessor', 'Processor "foo" is not registered.'),

--- a/tests/Source/MySqlDumpSourceTest.php
+++ b/tests/Source/MySqlDumpSourceTest.php
@@ -20,21 +20,23 @@ class MySqlDumpSourceTest extends TestCase
         $file = $scratch.'/zenstruck_backup.sql';
 
         $source = new MySqlDumpSource('mysqldump', 'zenstruck_backup');
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
 
         $source->fetch($scratch, new NullLogger());
         $this->assertFileExists($file);
-        $this->assertContains('Database: zenstruck_backup', file_get_contents($file));
+        $this->assertStringContainsString('Database: zenstruck_backup', file_get_contents($file));
     }
 
     /**
      * @test
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage mysqldump: Got error: 1049: Unknown database 'foobar' when selecting the database
+     *
+     *
      */
     public function it_fails_for_invalid_database()
     {
+        $this->expectExceptionMessage("mysqldump: Got error: 1049: Unknown database 'foobar' when selecting the database");
+        $this->expectException(\RuntimeException::class);
         $scratch = $this->getScratchDir();
 
         $source = new MySqlDumpSource('mysqldump', 'foobar');
@@ -44,11 +46,13 @@ class MySqlDumpSourceTest extends TestCase
     /**
      * @test
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage mysqldump: Got error: 2005: Unknown MySQL server host 'foobar'
+     *
+     *
      */
     public function it_fails_for_invalid_host()
     {
+        $this->expectExceptionMessage("mysqldump: Got error: 2005: Unknown MySQL server host 'foobar'");
+        $this->expectException(\RuntimeException::class);
         $scratch = $this->getScratchDir();
 
         $source = new MySqlDumpSource('mysqldump', 'zenstruck_backup', 'foobar');

--- a/tests/Source/RsyncSourceTest.php
+++ b/tests/Source/RsyncSourceTest.php
@@ -19,8 +19,8 @@ class RsyncSourceTest extends TestCase
         $scratch = $this->getScratchDir();
 
         $source = new RsyncSource('rysnc', $this->getFixtureDir());
-        $this->assertFileNotExists($scratch.'/Fixtures/foo.txt');
-        $this->assertFileNotExists($scratch.'/Fixtures/bar/baz.txt');
+        $this->assertFileDoesNotExist($scratch.'/Fixtures/foo.txt');
+        $this->assertFileDoesNotExist($scratch.'/Fixtures/bar/baz.txt');
 
         $source->fetch($scratch, new NullLogger());
         $this->assertFileExists($scratch.'/Fixtures/foo.txt');
@@ -29,12 +29,12 @@ class RsyncSourceTest extends TestCase
 
     /**
      * @test
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage rsync: change_dir "/foo" failed: No such file or directory (2)
      */
     public function it_fails_for_invalid_directory()
     {
+        #$this->expectExceptionMessage("rsync: change_dir \"/foo\" failed: No such file or directory (2)");
+        $this->expectExceptionMessage("rsync: [sender] change_dir \"/foo\" failed: No such file or directory (2)");
+        $this->expectException(\RuntimeException::class);
         $scratch = $this->getScratchDir();
 
         $source = new RsyncSource('rsync', '/foo/bar');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,15 +16,12 @@ use Zenstruck\Backup\Source;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    /** @var Filesystem */
-    protected $filesystem;
+    protected Filesystem $filesystem;
+    protected BackupCollection $collection;
 
-    /** @var BackupCollection */
-    protected $collection;
-
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->filesystem = new Filesystem();
 
@@ -39,22 +36,22 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->removeScratchDir();
     }
 
-    protected function getFixtureDir()
+    protected function getFixtureDir(): string
     {
         return __DIR__.'/Fixtures';
     }
 
-    protected function getScratchDir()
+    protected function getScratchDir(): string
     {
         return sys_get_temp_dir().'/zenstruck-backup-bundle';
     }
 
-    protected function createNullProfile($name = 'null_profile')
+    protected function createNullProfile($name = 'null_profile'): Profile
     {
         return new Profile(
             $name,
@@ -76,17 +73,17 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
 class NullProcessor implements Processor
 {
-    public function getName()
+    public function getName(): string
     {
         return 'null_processor';
     }
 
-    public function process($scratchDir, Namer $namer, LoggerInterface $logger)
+    public function process(string $scratchDir, Namer $namer, LoggerInterface $logger): string
     {
-        // noop
+        return "";
     }
 
-    public function cleanup($filename, LoggerInterface $logger)
+    public function cleanup(string $filename, LoggerInterface $logger)
     {
         // noop
     }
@@ -94,12 +91,12 @@ class NullProcessor implements Processor
 
 class NullSource1 implements Source
 {
-    public function getName()
+    public function getName(): string
     {
         return 'null_source1';
     }
 
-    public function fetch($scratchDir, LoggerInterface $logger)
+    public function fetch(string $scratchDir, LoggerInterface $logger)
     {
         // noop
     }
@@ -107,7 +104,7 @@ class NullSource1 implements Source
 
 class NullSource2 extends NullSource1
 {
-    public function getName()
+    public function getName(): string
     {
         return 'null_source2';
     }
@@ -115,14 +112,14 @@ class NullSource2 extends NullSource1
 
 class NullDestination1 implements Destination
 {
-    public function push($filename, LoggerInterface $logger)
+    public function push(string $filename, LoggerInterface $logger): Backup
     {
         return new Backup('null', 0, new \DateTime());
     }
 
-    public function get($key)
+    public function get(string $key): Backup
     {
-        // noop
+        return new Backup('null', 0, new \DateTime());
     }
 
     public function delete($key)
@@ -130,12 +127,12 @@ class NullDestination1 implements Destination
         // noop
     }
 
-    public function all()
+    public function all(): BackupCollection
     {
-        // noop
+        return new BackupCollection();
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'null_destination1';
     }
@@ -143,7 +140,7 @@ class NullDestination1 implements Destination
 
 class NullDestination2 extends NullDestination1
 {
-    public function getName()
+    public function getName(): string
     {
         return 'null_destination2';
     }


### PR DESCRIPTION
, add support symfony 6, add strong types.

Please check for BC checks of strong types.

I am not sure about these changes. Nullable or not.
https://github.com/kbond/php-backup/compare/master...Chris53897:php-backup:feature/modernize?expand=1#diff-abf1fa77a19f720052b75bc802df0260157b9064d8c3c12a80794f01e9acc065R130

I did not run the 3 tests of `mysqldump` (as not installed at my system)
The `rsync` output is a bit different. That may differs from rsync version.

To test final classes this can be used (https://phpunit.readthedocs.io/en/9.5/test-doubles.html). 
I did not use it before. Or do you have a better idea?
https://tomasvotruba.com/blog/2019/03/28/how-to-mock-final-classes-in-phpunit/

Improvements: 
Flysystem v3 instead of v1. 
GitHub Actions instead of Travis (I would suggest to do both in separate PR's).

